### PR TITLE
refactor: Pinia を導入し、ゲーム状態をストアに移行

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -3,7 +3,7 @@ export default defineNuxtConfig({
   devtools: { enabled: false },
 
   srcDir: "src",
-  modules: ["@nuxt/eslint"],
+  modules: ["@nuxt/eslint", "@pinia/nuxt"],
   ssr: false,
 
   css: ["~/assets/css/tailwind.css"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,9 @@
       "name": "nuxt-app",
       "hasInstallScript": true,
       "dependencies": {
-        "nuxt": "^4.0.0"
+        "@pinia/nuxt": "^0.11.3",
+        "nuxt": "^4.0.0",
+        "pinia": "^3.0.4"
       },
       "devDependencies": {
         "@nuxt/eslint": "^1.0.0",
@@ -3378,6 +3380,21 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/@pinia/nuxt": {
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/@pinia/nuxt/-/nuxt-0.11.3.tgz",
+      "integrity": "sha512-7WVNHpWx4qAEzOlnyrRC88kYrwnlR/PrThWT0XI1dSNyUAXu/KBv9oR37uCgYkZroqP5jn8DfzbkNF3BtKvE9w==",
+      "license": "MIT",
+      "dependencies": {
+        "@nuxt/kit": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "pinia": "^3.0.4"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -6211,6 +6228,21 @@
       "integrity": "sha512-+W7VmiVINB+ywl1HGXJXmrqkOhpKrIiVZV6tQuV54ZyQC7MMuBt81Vc336GMLoHBq5hV/F9eXgt5Mnx0Rha5Fg==",
       "license": "MIT"
     },
+    "node_modules/copy-anything": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
+      "integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-what": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
     "node_modules/core-js-compat": {
       "version": "3.48.0",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.48.0.tgz",
@@ -8438,6 +8470,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-what": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
+      "integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
     "node_modules/is-wsl": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
@@ -9283,6 +9327,12 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
     },
     "node_modules/mlly": {
       "version": "1.8.1",
@@ -10171,6 +10221,75 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/pinia": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pinia/-/pinia-3.0.4.tgz",
+      "integrity": "sha512-l7pqLUFTI/+ESXn6k3nu30ZIzW5E2WZF/LaHJEpoq6ElcLD+wduZoB2kBN19du6K/4FDpPMazY2wJr+IndBtQw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-api": "^7.7.7"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.5.0",
+        "vue": "^3.5.11"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pinia/node_modules/@vue/devtools-api": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.9.tgz",
+      "integrity": "sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-kit": "^7.7.9"
+      }
+    },
+    "node_modules/pinia/node_modules/@vue/devtools-kit": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.9.tgz",
+      "integrity": "sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-shared": "^7.7.9",
+        "birpc": "^2.3.0",
+        "hookable": "^5.5.3",
+        "mitt": "^3.0.1",
+        "perfect-debounce": "^1.0.0",
+        "speakingurl": "^14.0.1",
+        "superjson": "^2.2.2"
+      }
+    },
+    "node_modules/pinia/node_modules/@vue/devtools-shared": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.9.tgz",
+      "integrity": "sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==",
+      "license": "MIT",
+      "dependencies": {
+        "rfdc": "^1.4.1"
+      }
+    },
+    "node_modules/pinia/node_modules/birpc": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
+      "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/pinia/node_modules/perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "license": "MIT"
     },
     "node_modules/pkg-types": {
       "version": "2.3.0",
@@ -11078,6 +11197,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "license": "MIT"
+    },
     "node_modules/rollup": {
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
@@ -11547,6 +11672,15 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/speakingurl": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
+      "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/srvx": {
       "version": "0.11.9",
       "resolved": "https://registry.npmjs.org/srvx/-/srvx-0.11.9.tgz",
@@ -11740,6 +11874,18 @@
       },
       "peerDependencies": {
         "postcss": "^8.4.32"
+      }
+    },
+    "node_modules/superjson": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
+      "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
+      "license": "MIT",
+      "dependencies": {
+        "copy-anything": "^4"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/supports-color": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "postinstall": "nuxt prepare"
   },
   "dependencies": {
-    "nuxt": "^4.0.0"
+    "@pinia/nuxt": "^0.11.3",
+    "nuxt": "^4.0.0",
+    "pinia": "^3.0.4"
   },
   "devDependencies": {
     "@nuxt/eslint": "^1.0.0",

--- a/src/components/board/boardMain.vue
+++ b/src/components/board/boardMain.vue
@@ -27,6 +27,8 @@
 </template>
 
 <script setup lang="ts" scoped>
+  import { useNotificationStore } from "~/stores/notification";
+
   const notification = useNotificationStore();
 </script>
 

--- a/src/components/board/boardMain.vue
+++ b/src/components/board/boardMain.vue
@@ -1,357 +1,39 @@
 <template>
   <transition name="slide-fade">
     <div
-      v-if="isNotificationVisible"
-      :key="notificationKey"
+      v-if="notification.isVisible"
+      :key="notification.key"
       class="notification"
     >
       <p class="heading">
-        {{ notification[0] }}
+        {{ notification.text[0] }}
       </p>
-      <p>{{ notification[1] }}</p>
+      <p>{{ notification.text[1] }}</p>
     </div>
   </transition>
   <main class="mx-4 flex-grow overflow-scroll">
     <div
       class="game-board mx-auto grid h-[160vmin] max-h-[64rem] w-[160vmin] max-w-5xl grid-cols-[repeat(15,minmax(0,1fr))] border border-gray-300"
     >
-      <!-- <div
-        v-for="i in new Array(225)"
-        :key="i"
-        class="grid-item border-gray-240 border-[1px]"
-      > -->
-      <!-- <BoardTile /> -->
       <BoardTile
-        v-for="(n, index) in 225"
+        v-for="(_, index) in 225"
         :key="index"
         class="grid-item border-[min(0.2vmin,2.048px)] border-white"
         :number="index"
-        :cell-data="cellData"
-        :selected-cell="selectedCell"
-        :side="side"
-        @click-tile-emits="clickTile"
       />
     </div>
   </main>
-  <boardMenu
-    :selected-cell="selectedCell"
-    :selected-cell-number="selectedCellNumber"
-    :max-cell-number="maxCellNumber"
-    :is-editable="isEditable"
-    @submit-button-on-click-emits="submitButtonOnClick"
-  />
+  <boardMenu />
 </template>
 
 <script setup lang="ts" scoped>
-  /**
-   * 手番
-   * 1:青，-1:赤
-   */
-  const side = ref<number>(1);
-
-  /**
-   * 13*13 のマス目データ 初期値は0
-   */
-  const cellData = ref<number[][]>(
-    [...Array(13)].map((_) => Array(13).fill(0)),
-  );
-
-  /**
-   * 選択されているセルに入力できる値の最大値
-   */
-  const maxCellNumber = ref(10);
-
-  // for (let i = 0; i < cellData.value.length; i++) {
-  //   for (let j = 0; j < cellData.value.length; j++) {
-  //     cellData.value[i][j] = 13 * j + i;
-  //   }
-  // }
-
-  /**
-   * 選択されているセルの値
-   *
-   * `[-1, -1]` の時は選択されていないとき
-   */
-  const selectedCell = ref<[number, number]>([-1, -1]);
-  const selectedCellNumber = ref<number>(0);
-
-  // 選択されたセルの座標が変化したとき
-  // selectedCellNumber (選択されたセルの数値) を更新する
-  watchEffect(() => {
-    // どのセルも選択されていないとき，セルの値を1000とする
-    selectedCellNumber.value =
-      selectedCell.value[0] >= 0
-        ? (cellData.value[selectedCell.value[0]]?.[selectedCell.value[1]] ?? 1000)
-        : 1000;
-    // console.debug("selectedCellNumber.value", selectedCellNumber.value);
-  });
-
-  // /////////////////////////////////////////////////////////
-  // <!-- 通知 -->
-  // /////////////////////////////////////////////////////////
-
-  // 通知する文字
-  const notification = ref<[string, string]>(["", ""]);
-
-  // 通知の実装
-  const notificationData: [string, string][] = [
-    [
-      "ルール：上限",
-      "同じ道路番号 n に挟まれている場合，新たに設置する道路番号は n 以下である必要があります",
-    ],
-    [
-      "ルール：取り壊し",
-      "道路番号ｎ-1のマスを、道路番号 n の道で挟んだとき，挟まれたマスの道は取り壊されます。",
-    ],
-  ];
-
-  /**
-   * 通知が表示されているかどうか
-   */
-  const isNotificationVisible = ref(false);
-
-  /**
-   * 異なる通知を区別するためのキー
-   */
-  const notificationKey = ref(0);
-
-  /**
-   * setTimeout の戻り値を保管
-   * (タイムアウトをクリアできるようにする)
-   */
-  const timeoutId = ref<ReturnType<typeof setTimeout>>(); // setTimeout の ID を保持
-
-  /**
-   * 通知を表示
-   */
-  const showNotification = (id: number): void => {
-    if (isNotificationVisible.value) {
-      // すでに表示されている場合、一度非表示にする
-      isNotificationVisible.value = false;
-      // 前回の setTimeout をクリア
-      clearTimeout(timeoutId.value);
-
-      // 少し遅らせて再表示（アニメーションが確実に適用されるように）
-      setTimeout(() => {
-        // keyを変更して強制的に再描画
-
-        notificationKey.value++;
-        isNotificationVisible.value = true;
-        scheduleHideNotification(id);
-      }, 100); // 100ms の小さな遅延を入れる
-    } else {
-      // 通知を表示
-      isNotificationVisible.value = true;
-      scheduleHideNotification(id);
-    }
-  };
-
-  /**
-   * 通知を非表示にするタイマーをスケジュールする
-   * @param id 通知テキストのID
-   */
-  const scheduleHideNotification = (id: number): void => {
-    // 以前のタイムアウトをクリア
-    clearTimeout(timeoutId.value);
-    const entry = notificationData[id];
-    if (entry !== undefined) {
-      notification.value = entry;
-    }
-
-    // タイムアウトのIDを記録
-    timeoutId.value = setTimeout(() => {
-      isNotificationVisible.value = false;
-    }, 5000); // 5秒後に消える
-  };
-
-  // /////////////////////////////////////////////////////////
-  // <!-- 通知おわり -->
-  // /////////////////////////////////////////////////////////
-
-  /**
-   * ルール：取り壊しの処理中かどうか
-   *
-   * true  - 処理中  タイルをクリックできない
-   * false - 処理中でない  タイルをクリックできる
-   */
-  const isBeingRemoved = ref(false);
-
-  /**
-   * boradTile から呼び出されるEmmits
-   */
-  const clickTile = (clickTileData: [number, number, number, number]): void => {
-    maxCellNumber.value = clickTileData[2];
-    // 取り壊しの処理中はクリックできないようにする
-    if (isBeingRemoved.value) return;
-    if (
-      // 同じマスが二度クリックされたとき
-      selectedCell.value[0] === clickTileData[0] &&
-      selectedCell.value[1] === clickTileData[1]
-    ) {
-      // 選択解除
-      selectedCell.value = [-1, -1];
-    } else {
-      // 直前までと異なるマスがクリックされた時，クリックされたセルの座標を代入
-      [selectedCell.value[0], selectedCell.value[1]] = clickTileData;
-
-      // notificationTypeが0のとき，通知を表示する
-      if (clickTileData[3] === 0) {
-        showNotification(0);
-      }
-    }
-  };
-
-  /**
-   * セルが選択されているかどうか(数値を入力できるかどうか)
-   */
-  const isEditable = ref<boolean>(false);
-
-  // 選択されているセルが変わるごとに isEditable に値を代入する
-  watchEffect(() => {
-    // console.debug("isEditableのためのwatchEffect");
-    // console.debug("selectedCellNumber.value", selectedCellNumber.value);
-
-    // 選択されたセルが存在する(座標が[-1, -1]でない) かつ 選択されたセルに入っている値が0である ときのみ true に
-    isEditable.value =
-      selectedCell.value[0] !== -1 &&
-      selectedCell.value[1] !== -1 &&
-      selectedCellNumber.value === 0;
-  });
-
-  /**
-   * boardMenu からのEmitsがここに来る
-   *
-   * 入力を確定させたとき
-   */
-  const submitButtonOnClick = (submittedNumber: number): void => {
-    // 入力されたセルに値を代入
-    const row = cellData.value[selectedCell.value[0]];
-    if (row !== undefined) {
-      row[selectedCell.value[1]] = submittedNumber * side.value;
-    }
-
-    // 手番を交代
-    side.value = side.value * -1;
-
-    // 取り壊しの処理を開始
-    isBeingRemoved.value = true;
-
-    type Coordinate = { x: number; y: number };
-
-    /**
-     * 取り壊される座標のリスト;
-     */
-    const removedList: Coordinate[] = [];
-
-    /**
-     * 8方向の定義
-     * ```
-     * [-1, -1], [-1, 0], [-1, 1],
-     * [ 0, -1],          [ 0, 1],
-     * [ 1, -1], [ 1, 0], [ 1, 1]
-     * ```
-     */
-    const directions: [number, number][] = [
-      [-1, -1],
-      [-1, 0],
-      [-1, 1],
-      [0, -1],
-      [0, 1],
-      [1, -1],
-      [1, 0],
-      [1, 1],
-    ];
-
-    // x座標
-    for (let x = 0; x < 13; x++) {
-      // y座標
-      for (let y = 0; y < 13; y++) {
-        /**
-         * 着目するセルの値
-         */
-        const n = Math.abs(cellData.value[x]?.[y] ?? 0);
-
-        // 値が0の場合は繰り返しをスキップする
-        if (n === 0) continue;
-
-        // 値が1の場合は繰り返しをスキップする
-        if (n === 1) continue;
-
-        for (const [dx, dy] of directions) {
-          const currentChain = []; // この方向で連続する n-1 のセルを記録
-          let step = 1;
-          while (true) {
-            // ラッピングを考慮して新しい座標を計算
-            const nx = (x + dx * step + 13) % 13;
-            const ny = (y + dy * step + 13) % 13;
-
-            // 探索中に起点に戻ってきた場合
-            if (nx === x && ny === y) {
-              // 1マス以上連続していた場合は、取り壊し対象として記録
-              if (currentChain.length > 0) {
-                removedList.push(...currentChain);
-              }
-              break;
-            }
-
-            const currentValue = Math.abs(cellData.value[nx]?.[ny] ?? 0);
-
-            if (step === 1) {
-              // 最初のセルは必ず n-1 でなければならない
-              if (currentValue !== n - 1) break;
-              currentChain.push({ x: nx, y: ny });
-            } else if (currentValue === n - 1) {
-              // 連続する n-1 のセルを追加
-              currentChain.push({ x: nx, y: ny });
-            } else if (currentValue === n) {
-              // チェーンが1マス以上ある場合は対象として記録
-              if (currentChain.length > 0) {
-                removedList.push(...currentChain);
-              }
-              break;
-            } else {
-              // 条件に合わない場合は探索終了
-              break;
-            }
-            step++;
-          }
-        }
-      }
-    }
-
-    // 取り壊されるマスが存在するとき
-    if (removedList.length > 0) {
-      // 通知を表示
-      showNotification(1);
-      // 「取り壊し」が起きたことをわかりやすくするため，取り壊すまでに2秒待機
-      setTimeout(function () {
-        // すべての探索が終わった後、一括で取り壊し（対象セルを0に更新）
-        for (const coord of removedList) {
-          const coordRow = cellData.value[coord.x];
-          if (coordRow !== undefined) {
-            coordRow[coord.y] = 0;
-          }
-        }
-      }, 2000);
-    }
-    isBeingRemoved.value = false;
-  };
+  const notification = useNotificationStore();
 </script>
 
 <style scoped>
   .game-board {
     background-color: #e7e7e7;
   }
-  /* .grid-item { */
-  /* background-color: #c0c0c0; */
-  /* } */
-
-  /* .grid-item:nth-child(-n + 15),
-  .grid-item:nth-child(15n + 1),
-  .grid-item:nth-child(15n + 15),
-  .grid-item:nth-last-child(-n + 15) {
-    background-color: #d6d6d6;
-  } */
 
   /* 通知のデザイン */
   .notification {

--- a/src/components/board/boardMenu.vue
+++ b/src/components/board/boardMenu.vue
@@ -6,11 +6,11 @@
         <button
           class="my-auto rounded-md bg-slate-100 fill-current"
           :class="{
-            'hover:bg-gray-300': isEditable && selectedNumber > 1,
-            'cursor-default text-slate-300': !isEditable || selectedNumber == 1,
+            'hover:bg-gray-300': game.isEditable && selectedNumber > 1,
+            'cursor-default text-slate-300': !game.isEditable || selectedNumber == 1,
           }"
           @click="
-            if (isEditable && selectedNumber > 1) {
+            if (game.isEditable && selectedNumber > 1) {
               selectedNumber--;
             }
           "
@@ -29,35 +29,33 @@
       <div class="grid h-full w-full grid-flow-row gap-3">
         <div
           class="mt-[max(2dvh,0.75rem)] text-center text-3xl"
-          :class="{ 'text-slate-300': !isEditable }"
+          :class="{ 'text-slate-300': !game.isEditable }"
         >
           {{ selectedNumber }}
         </div>
-        <!-- <div class="mb-[max(5dvh,2.5rem)] flex flex-col"> -->
         <!-- スライダー -->
         <input
           v-model="selectedNumber"
           type="range"
           class="input-range relative"
           :class="{
-            'input-range_gray': !isEditable || menuPorps.maxCellNumber == 1,
+            'input-range_gray': !game.isEditable || game.maxCellNumber == 1,
           }"
           name="number_input"
           min="1"
-          :max="menuPorps.maxCellNumber"
+          :max="game.maxCellNumber"
           step="1"
           :value="1"
-          :disabled="!isEditable"
+          :disabled="!game.isEditable"
         />
         <!-- 目盛り -->
         <div
           class="mb-[max(2dvh,0.75rem)] flex w-full justify-between text-xl"
-          :class="{ 'text-slate-300': !isEditable }"
+          :class="{ 'text-slate-300': !game.isEditable }"
         >
           <div>1</div>
-          <div>{{ menuPorps.maxCellNumber }}</div>
+          <div>{{ game.maxCellNumber }}</div>
         </div>
-        <!-- </div> -->
       </div>
       <!-- 右のボタン -->
       <div class="mx-4 flex justify-center">
@@ -65,13 +63,12 @@
           class="my-auto rounded-md bg-slate-100 fill-current"
           :class="{
             'hover:bg-gray-300':
-              // 入力可能 かつ 数字が最大値より小さい
-              isEditable && selectedNumber < menuPorps.maxCellNumber,
+              game.isEditable && selectedNumber < game.maxCellNumber,
             'cursor-default text-slate-300':
-              !isEditable || selectedNumber == menuPorps.maxCellNumber,
+              !game.isEditable || selectedNumber == game.maxCellNumber,
           }"
           @click="
-            if (isEditable && selectedNumber < menuPorps.maxCellNumber) {
+            if (game.isEditable && selectedNumber < game.maxCellNumber) {
               selectedNumber++;
             }
           "
@@ -94,8 +91,8 @@
       class="flex aspect-square w-16 items-stretch lg:min-w-[20vw]"
       :class="{
         'bg-lime-400 text-lime-800 hover:bg-lime-500 active:bg-lime-600':
-          isEditable,
-        'cursor-default bg-slate-100 text-slate-300 ': !isEditable,
+          game.isEditable,
+        'cursor-default bg-slate-100 text-slate-300 ': !game.isEditable,
       }"
       @click="clickSubmitButton()"
     >
@@ -113,52 +110,21 @@
 </template>
 
 <script setup lang="ts" scoped>
-  interface Props {
-    /**
-     *  選択されているセルの座標
-     */
-    selectedCell: number[];
-
-    /**
-     * 選択されているセルに保存されている数値
-     */
-    selectedCellNumber: number | null;
-
-    /**
-     * 周囲8マスのうち，最大の数値
-     */
-    maxCellNumber: number;
-
-    /**
-     * スライダーを用いて入力できるかどうか(セルが選択されているかどうか)
-     */
-    isEditable: boolean;
-  }
+  const game = useGameStore();
 
   /**
-   * boardMainから受け取るデータ
-   */
-  const menuPorps = defineProps<Props>();
-
-  interface Emits {
-    (event: "submitButtonOnClickEmits", submittedNumber: number): void;
-  }
-  const submitButtonOnClickEmits = defineEmits<Emits>();
-
-  /**
-   * スライダーでユーザーが選んだ数値
+   * スライダーでユーザーが選んだ数値（UI状態のためローカルに保持）
    */
   const selectedNumber = ref(1);
 
   function clickSubmitButton() {
-    if (!menuPorps.isEditable) {
-      return;
-    }
-    submitButtonOnClickEmits("submitButtonOnClickEmits", selectedNumber.value);
+    if (!game.isEditable) return;
+    game.submitMove(selectedNumber.value);
   }
 
+  // maxCellNumber が変わったらスライダーを1にリセット
   watch(
-    () => menuPorps.maxCellNumber,
+    () => game.maxCellNumber,
     () => {
       selectedNumber.value = 1;
     },
@@ -167,57 +133,49 @@
 
 <style lang="scss" scoped>
   .input-range {
-    -webkit-appearance: none; // スタイルリセット
+    -webkit-appearance: none;
     appearance: none;
     cursor: pointer;
-    background: rgb(163 230 53); // 背景
-    height: 20px; // バーの高さ
-    width: 100%; // スライダーの幅
-    border: solid 3px rgb(163 230 53); // バーまわりの線
-    outline: 0; // アウトラインを消して代わりにfocusのスタイルをあてる
+    background: rgb(163 230 53);
+    height: 20px;
+    width: 100%;
+    border: solid 3px rgb(163 230 53);
+    outline: 0;
 
-    // 入力できないときのCSS
     &.input-range_gray {
       background: rgb(241 245 249);
       border: rgb(241 245 249);
       pointer-events: none;
-      // webkit用
       &::-webkit-slider-thumb {
         background: rgb(203 213 225);
       }
     }
-    // firefox用
     &::-moz-range-thumb {
       background: rgb(203 213 225);
     }
 
     &:focus {
-      // box-shadow: 0 0 3px #78cdff;
       outline: 1px solid;
       outline-color: rgba(162, 230, 53, 0.4);
       outline-offset: 2px;
     }
-    // -webkit-向けのつまみ
     &::-webkit-slider-thumb {
-      -webkit-appearance: none; // デフォルトのつまみのスタイルを解除
-      background: #4a7505; // 背景色
-      width: 10px; // 幅
-      height: 35px; // 高さ
-      border-radius: 0%; // 円形に
+      -webkit-appearance: none;
+      background: #4a7505;
+      width: 10px;
+      height: 35px;
+      border-radius: 0%;
     }
-    // -moz-向けのつまみ
     &::-moz-range-thumb {
-      background: #4a7505; // 背景色
-      width: 10px; // 幅
-      height: 35px; // 高さ
-      border-radius: 0%; // 円形に
-      border: none; // デフォルトの線を消す
+      background: #4a7505;
+      width: 10px;
+      height: 35px;
+      border-radius: 0%;
+      border: none;
     }
-    // Firefoxで点線が周りに表示されてしまう問題の解消
     &::-moz-focus-outer {
       border: 0;
     }
-    // つまみをドラッグしているときのスタイル
     &:active::-webkit-slider-thumb {
       box-shadow: 0px 5px 10px -2px rgba(0, 0, 0, 0.3);
     }

--- a/src/components/board/boardMenu.vue
+++ b/src/components/board/boardMenu.vue
@@ -7,7 +7,7 @@
           class="my-auto rounded-md bg-slate-100 fill-current"
           :class="{
             'hover:bg-gray-300': game.isEditable && selectedNumber > 1,
-            'cursor-default text-slate-300': !game.isEditable || selectedNumber == 1,
+            'cursor-default text-slate-300': !game.isEditable || selectedNumber === 1,
           }"
           @click="
             if (game.isEditable && selectedNumber > 1) {
@@ -39,7 +39,7 @@
           type="range"
           class="input-range relative"
           :class="{
-            'input-range_gray': !game.isEditable || game.maxCellNumber == 1,
+            'input-range_gray': !game.isEditable || game.maxCellNumber === 1,
           }"
           name="number_input"
           min="1"
@@ -64,7 +64,7 @@
             'hover:bg-gray-300':
               game.isEditable && selectedNumber < game.maxCellNumber,
             'cursor-default text-slate-300':
-              !game.isEditable || selectedNumber == game.maxCellNumber,
+              !game.isEditable || selectedNumber === game.maxCellNumber,
           }"
           @click="
             if (game.isEditable && selectedNumber < game.maxCellNumber) {

--- a/src/components/board/boardMenu.vue
+++ b/src/components/board/boardMenu.vue
@@ -45,7 +45,6 @@
           min="1"
           :max="game.maxCellNumber"
           step="1"
-          :value="1"
           :disabled="!game.isEditable"
         />
         <!-- 目盛り -->
@@ -110,6 +109,8 @@
 </template>
 
 <script setup lang="ts" scoped>
+  import { useGameStore } from "~/stores/game";
+
   const game = useGameStore();
 
   /**

--- a/src/components/board/boardTile.vue
+++ b/src/components/board/boardTile.vue
@@ -46,6 +46,7 @@
 
 <script lang="ts" setup scoped>
   import { cellX, cellY, isInEdge } from "~/composables/useCellCoords";
+  import { DIRECTIONS } from "~/composables/useGameLogic";
   import { useGameStore } from "~/stores/game";
 
   const game = useGameStore();
@@ -107,17 +108,6 @@
       cellColor.value = "cell_none";
     }
   });
-
-  const DIRECTIONS: { [key: number]: [number, number] } = {
-    0: [-1, -1],
-    1: [0, -1],
-    2: [1, -1],
-    3: [-1, 0],
-    5: [1, 0],
-    6: [-1, 1],
-    7: [0, 1],
-    8: [1, 1],
-  };
 
   // 周囲のセルとの道を更新する
   watchEffect(() => {

--- a/src/components/board/boardTile.vue
+++ b/src/components/board/boardTile.vue
@@ -46,13 +46,14 @@
 
 <script lang="ts" setup scoped>
   import { useCellCoords } from "~/composables/useCellCoords";
+  import { useGameStore } from "~/stores/game";
 
   const { cellX, cellY, isInEdge } = useCellCoords();
   const game = useGameStore();
 
   interface Props {
     /**
-     * 1~225の数字の番号
+     * 0~224のセル番号
      */
     number: number;
   }

--- a/src/components/board/boardTile.vue
+++ b/src/components/board/boardTile.vue
@@ -45,10 +45,9 @@
 </template>
 
 <script lang="ts" setup scoped>
-  import { useCellCoords } from "~/composables/useCellCoords";
+  import { cellX, cellY, isInEdge } from "~/composables/useCellCoords";
   import { useGameStore } from "~/stores/game";
 
-  const { cellX, cellY, isInEdge } = useCellCoords();
   const game = useGameStore();
 
   interface Props {
@@ -109,23 +108,23 @@
     }
   });
 
+  const DIRECTIONS: { [key: number]: [number, number] } = {
+    0: [-1, -1],
+    1: [0, -1],
+    2: [1, -1],
+    3: [-1, 0],
+    5: [1, 0],
+    6: [-1, 1],
+    7: [0, 1],
+    8: [1, 1],
+  };
+
   // 周囲のセルとの道を更新する
   watchEffect(() => {
-    const directions: { [key: number]: [number, number] } = {
-      0: [-1, -1],
-      1: [0, -1],
-      2: [1, -1],
-      3: [-1, 0],
-      5: [1, 0],
-      6: [-1, 1],
-      7: [0, 1],
-      8: [1, 1],
-    };
-
     const x = cellX(tileProps.number);
     const y = cellY(tileProps.number);
 
-    for (const [keyStr, [dx, dy]] of Object.entries(directions)) {
+    for (const [keyStr, [dx, dy]] of Object.entries(DIRECTIONS)) {
       const key = Number(keyStr);
       const nextX = (x + dx + 13) % 13;
       const nextY = (y + dy + 13) % 13;

--- a/src/components/board/boardTile.vue
+++ b/src/components/board/boardTile.vue
@@ -11,15 +11,14 @@
       :class="cellColor"
     >
       <!-- 数字 -->
-      <div v-if="cellData" class="z-5 mx-auto my-auto text-[min(4.2vmin,27px)]">
+      <div class="z-5 mx-auto my-auto text-[min(4.2vmin,27px)]">
         {{
           Math.abs(
-            tileProps.cellData[cellX(tileProps.number)]?.[
+            game.cellData[cellX(tileProps.number)]?.[
               cellY(tileProps.number)
             ] ?? 0,
           )
         }}
-        <!-- {{ tileProps.number }} -->
       </div>
     </div>
     <!-- まわりに伸びる道(8本用意する, 4は無し) -->
@@ -46,76 +45,18 @@
 </template>
 
 <script lang="ts" setup scoped>
-  const isInEdge = (n: number) => {
-    // 0~14の範囲にあるか
-    if (n >= 0 && n <= 14) return true;
+  import { useCellCoords } from "~/composables/useCellCoords";
 
-    // 15で割って14余る数か
-    if (n % 15 === 14) return true;
-
-    // 15の倍数か
-    if (n % 15 === 0) return true;
-
-    // 211~225の範囲にあるか
-    if (n >= 210 && n <= 224) return true;
-
-    // いずれの条件にも当てはまらない場合
-    return false;
-  };
+  const { cellX, cellY, isInEdge } = useCellCoords();
+  const game = useGameStore();
 
   interface Props {
     /**
-     *  1~225の数字の番号
+     * 1~225の数字の番号
      */
     number: number;
-
-    /**
-     * 13*13の二次元配列
-     */
-    cellData: number[][];
-
-    /**
-     * 選択されたセルの座標 [x, y]
-     */
-    selectedCell: [number, number];
-
-    /**
-     * 手番
-     * 1:青 -1:赤
-     */
-    side: number;
   }
   const tileProps = defineProps<Props>();
-
-  /**
-   * boardMain.vue に，選択されたセルの場所を送るEmitsの型
-   */
-  interface Emits {
-    (
-      event: "clickTileEmits",
-      /**
-       *  @param clickTileData [x, y, newNumber, notificationType]
-       */
-      clickTileData: [number, number, number, number],
-    ): void;
-  }
-
-  /**
-   * boardMain.vue に 選択されたセルの場所を送るEmitsの型
-   */
-  const tileEmits = defineEmits<Emits>();
-
-  // /**
-  //  * index.vue に通知を送るEmmitsの型
-  //  */
-  // interface notificationEmits {
-  //   (event: "sendNotification", notificationData: [string, string]): void;
-  // }
-
-  // /**
-  //  * index.vue に通知を送るEmmits
-  //  */
-  // const tileNotificationEmits = defineEmits<notificationEmits>();
 
   /**
    * 現在のセルの色
@@ -129,136 +70,6 @@
   >("cell_none");
 
   /**
-   * 選択されたセルに入っている数値
-   */
-  const cellNumber = ref<number>(0);
-
-  /**
-   * 周囲八マスの数値が代入される数値が代入される
-   */
-  const nextCellList = ref<number[]>(new Array(9).fill(0));
-
-  /**
-   * セルがクリックされたときに実行する関数
-   */
-  function clickTile() {
-    // セルに入れることができる最大の整数
-    let maxNumber = 0;
-
-    // 周囲8マスの値を取得
-    for (let i = 0; i < 9; i++) {
-      // console.debug("ifの前", i, maxNumber);
-      if (maxNumber < Math.abs(nextCellList.value[i] ?? 0)) {
-        maxNumber = Math.abs(nextCellList.value[i] ?? 0);
-      }
-    }
-    maxNumber++; // 隣り合ったセルの最大値より1だけ大きい値まで入力できる
-    // console.debug("ーーifの後", maxNumber);
-
-    /**
-     * 向かい合わせのセルの値が同じ組のうち，最小の値
-     */
-    let minFacingPair = 1000;
-
-    /**
-     * 向かい合わせのセルのリスト
-     */
-    const facingCellList: [number, number][] = [
-      [0, 8],
-      [1, 7],
-      [2, 6],
-      [3, 5],
-    ];
-
-    // 初期値: -1
-    let notificationType: number = -1;
-
-    // 向かい合わせのセルの数値が同じかどうか
-    for (const [j, k] of facingCellList) {
-      if (
-        Math.abs(nextCellList.value[j] ?? 0) === Math.abs(nextCellList.value[k] ?? 0) &&
-        Math.abs(nextCellList.value[j] ?? 0) < minFacingPair &&
-        Math.abs(nextCellList.value[j] ?? 0) !== 0
-      ) {
-        minFacingPair = Math.abs(nextCellList.value[j] ?? 0);
-      }
-    }
-
-    if (minFacingPair !== 1000) {
-      maxNumber = minFacingPair;
-      notificationType = 0;
-    }
-
-    // emitsの呼び出し
-    // boardMain.vue へ，選択されたセルの情報を送る
-    tileEmits("clickTileEmits", [
-      // x座標
-      cellX(tileProps.number),
-      // y座標
-      cellY(tileProps.number),
-      // セルにおける数値の最大値
-      maxNumber,
-      notificationType,
-    ]);
-  }
-
-  /**
-   * セルの番号(0~255)をもとに，どのマス目を指すか求める．x座標
-   * @param no セルの番号(0~255)
-   */
-  function cellX(no: number): number {
-    const result = remainder(no, 15);
-    let index: number;
-    if (result === 0) {
-      index = 13;
-    } else if (result === 14) {
-      index = 1;
-    } else {
-      index = result;
-    }
-    return index - 1; // 0～12 に調整
-  }
-
-  /**
-   * セルの番号(0~255)をもとに，どのマス目を指すか求める．x座標
-   * @param no セルの番号(0~255)
-   */
-  function cellY(no: number): number {
-    const result = quotient(no, 15);
-    let index: number;
-    if (result === 0) {
-      index = 13;
-    } else if (result === 14) {
-      index = 1;
-    } else {
-      index = result;
-    }
-    return index - 1; // 0～12 に調整
-  }
-
-  /**
-   * 商を求める関数
-   * @param dividend 割られる数
-   * @param divisor 割る数
-   */
-  function quotient(dividend: number, divisor: number): number {
-    return Math.floor(dividend / divisor);
-  }
-
-  /**
-   * 余りを求める関数
-   * @param dividend 割られる数
-   * @param divisor 割る数
-   */
-  function remainder(dividend: number, divisor: number): number {
-    return dividend % divisor;
-  }
-
-  //   watch(() => props.value, (newValue, oldValue) => {
-  //   console.log(`値が変わりました: ${oldValue} → ${newValue}`);
-  // });
-
-  /**
    * 周囲の8マスのうち，つながっているマスの番号にtrueが代入される
    *
    * ```
@@ -267,74 +78,62 @@
    * 6  7  8
    * ```
    */
-  const nextCells = ref<boolean[]>(new Array(8).fill(false));
+  const nextCells = ref<boolean[]>(new Array(9).fill(false));
 
-  // 選択されたセルの座標が変化したとき
-  // 選択されたセルの見た目を変える
-  // 選択されていないセルは，青・赤・0・のいずれかに分類
+  /**
+   * タイルがクリックされたときの処理
+   */
+  function clickTile() {
+    game.selectCell(cellX(tileProps.number), cellY(tileProps.number));
+  }
+
+  // セルの色を更新する
   watchEffect(() => {
-    cellNumber.value =
-      tileProps.cellData[cellX(tileProps.number)]?.[cellY(tileProps.number)] ?? 0;
+    const x = cellX(tileProps.number);
+    const y = cellY(tileProps.number);
+    const cellNumber = game.cellData[x]?.[y] ?? 0;
+
     if (
-      tileProps.selectedCell[0] === cellX(tileProps.number) &&
-      tileProps.selectedCell[1] === cellY(tileProps.number) &&
-      (tileProps.cellData[tileProps.selectedCell[0]]?.[
-        tileProps.selectedCell[1]
-      ] ?? -1) === 0
+      game.selectedCell[0] === x &&
+      game.selectedCell[1] === y &&
+      (game.cellData[game.selectedCell[0]]?.[game.selectedCell[1]] ?? -1) === 0
     ) {
-      // セルが選択されている場合
-      if (tileProps.side === 1) {
-        // 青の時
-        cellColor.value = "cell_blue_selected";
-      } else {
-        // 赤の時
-        cellColor.value = "cell_red_selected";
-      }
-    } else if (cellNumber.value > 0) {
-      // セルが選択されておらず，青の時
+      cellColor.value = game.side === 1 ? "cell_blue_selected" : "cell_red_selected";
+    } else if (cellNumber > 0) {
       cellColor.value = "cell_blue";
-    } else if (cellNumber.value < 0) {
-      // セルが選択されておらず，赤の時
+    } else if (cellNumber < 0) {
       cellColor.value = "cell_red";
     } else {
-      // セルが選択されておらず，ゼロの時
       cellColor.value = "cell_none";
     }
   });
 
-  // セルに入っている数値が変化したとき
-  // 周囲のセルとつながる道を書き換える
+  // 周囲のセルとの道を更新する
   watchEffect(() => {
     const directions: { [key: number]: [number, number] } = {
-      0: [-1, -1], // 左上
-      1: [0, -1], // 上
-      2: [1, -1], // 右上
-      3: [-1, 0], // 左
-      5: [1, 0], // 右
-      6: [-1, 1], // 左下
-      7: [0, 1], // 下
-      8: [1, 1], // 右下
+      0: [-1, -1],
+      1: [0, -1],
+      2: [1, -1],
+      3: [-1, 0],
+      5: [1, 0],
+      6: [-1, 1],
+      7: [0, 1],
+      8: [1, 1],
     };
+
+    const x = cellX(tileProps.number);
+    const y = cellY(tileProps.number);
 
     for (const [keyStr, [dx, dy]] of Object.entries(directions)) {
       const key = Number(keyStr);
-      const [x, y] = [cellX(tileProps.number), cellY(tileProps.number)];
-
-      // 13を足してから13で割ったあまりをとることで，隣のマスが盤面をはみ出した時，反対側のマス目を参照参照するようにした
       const nextX = (x + dx + 13) % 13;
       const nextY = (y + dy + 13) % 13;
 
-      const nextCellNumber = tileProps.cellData[nextX]?.[nextY] ?? 0;
-      nextCellList.value[key] = nextCellNumber;
-      // console.debug(nextCellList.value.toString());
-      if (
-        Math.abs((tileProps.cellData[x]?.[y] ?? 0) - nextCellNumber) <= 1 &&
-        nextCellNumber !== 0
-      ) {
-        nextCells.value[key] = true;
-      } else {
-        nextCells.value[key] = false;
-      }
+      const currentValue = game.cellData[x]?.[y] ?? 0;
+      const nextCellValue = game.cellData[nextX]?.[nextY] ?? 0;
+
+      nextCells.value[key] =
+        Math.abs(currentValue - nextCellValue) <= 1 && nextCellValue !== 0;
     }
   });
 </script>
@@ -352,8 +151,6 @@
   .cell {
     &_none {
       border-color: rgba(0, 0, 0, 0);
-      // color: var(--gray-color);
-      // border: none;
       color: rgba(0, 0, 0, 0);
     }
 
@@ -376,7 +173,6 @@
 
     &_red_selected {
       border-color: var(--red-color-light);
-      // outline: var(--red-color-light);
       color: rgba(0, 0, 0, 0);
     }
   }

--- a/src/composables/useCellCoords.ts
+++ b/src/composables/useCellCoords.ts
@@ -1,0 +1,35 @@
+/**
+ * タイル番号(0~224)とセル座標(0~12)の変換ユーティリティ
+ */
+export function useCellCoords() {
+  /**
+   * タイル番号(0~224) → X座標(0~12)
+   */
+  function cellX(no: number): number {
+    const result = no % 15;
+    const index = result === 0 ? 13 : result === 14 ? 1 : result;
+    return index - 1;
+  }
+
+  /**
+   * タイル番号(0~224) → Y座標(0~12)
+   */
+  function cellY(no: number): number {
+    const result = Math.floor(no / 15);
+    const index = result === 0 ? 13 : result === 14 ? 1 : result;
+    return index - 1;
+  }
+
+  /**
+   * 外周タイル（トーラスの折り返し表示用）かどうか
+   */
+  function isInEdge(no: number): boolean {
+    if (no >= 0 && no <= 14) return true;
+    if (no % 15 === 14) return true;
+    if (no % 15 === 0) return true;
+    if (no >= 210 && no <= 224) return true;
+    return false;
+  }
+
+  return { cellX, cellY, isInEdge };
+}

--- a/src/composables/useCellCoords.ts
+++ b/src/composables/useCellCoords.ts
@@ -1,35 +1,28 @@
 /**
- * タイル番号(0~224)とセル座標(0~12)の変換ユーティリティ
+ * タイル番号(0~224) → X座標(0~12)
  */
-export function useCellCoords() {
-  /**
-   * タイル番号(0~224) → X座標(0~12)
-   */
-  function cellX(no: number): number {
-    const result = no % 15;
-    const index = result === 0 ? 13 : result === 14 ? 1 : result;
-    return index - 1;
-  }
+export function cellX(no: number): number {
+  const result = no % 15;
+  const index = result === 0 ? 13 : result === 14 ? 1 : result;
+  return index - 1;
+}
 
-  /**
-   * タイル番号(0~224) → Y座標(0~12)
-   */
-  function cellY(no: number): number {
-    const result = Math.floor(no / 15);
-    const index = result === 0 ? 13 : result === 14 ? 1 : result;
-    return index - 1;
-  }
+/**
+ * タイル番号(0~224) → Y座標(0~12)
+ */
+export function cellY(no: number): number {
+  const result = Math.floor(no / 15);
+  const index = result === 0 ? 13 : result === 14 ? 1 : result;
+  return index - 1;
+}
 
-  /**
-   * 外周タイル（トーラスの折り返し表示用）かどうか
-   */
-  function isInEdge(no: number): boolean {
-    if (no >= 0 && no <= 14) return true;
-    if (no % 15 === 14) return true;
-    if (no % 15 === 0) return true;
-    if (no >= 210 && no <= 224) return true;
-    return false;
-  }
-
-  return { cellX, cellY, isInEdge };
+/**
+ * 外周タイル（トーラスの折り返し表示用）かどうか
+ */
+export function isInEdge(no: number): boolean {
+  if (no >= 0 && no <= 14) return true;
+  if (no % 15 === 14) return true;
+  if (no % 15 === 0) return true;
+  if (no >= 210 && no <= 224) return true;
+  return false;
 }

--- a/src/composables/useGameLogic.ts
+++ b/src/composables/useGameLogic.ts
@@ -11,7 +11,7 @@
  * 6  7  8
  * ```
  */
-const DIRECTIONS: { [key: number]: [number, number] } = {
+export const DIRECTIONS: { [key: number]: [number, number] } = {
   0: [-1, -1],
   1: [0, -1],
   2: [1, -1],

--- a/src/composables/useGameLogic.ts
+++ b/src/composables/useGameLogic.ts
@@ -1,0 +1,136 @@
+/**
+ * ゲームロジックの純粋関数群
+ * ストアやコンポーネントに依存しないため、単体テストが容易
+ */
+
+/**
+ * 方向定義（boardTile.vueの既存インデックス体系を維持）
+ * ```
+ * 0  1  2
+ * 3  -  5
+ * 6  7  8
+ * ```
+ */
+const DIRECTIONS: { [key: number]: [number, number] } = {
+  0: [-1, -1],
+  1: [0, -1],
+  2: [1, -1],
+  3: [-1, 0],
+  5: [1, 0],
+  6: [-1, 1],
+  7: [0, 1],
+  8: [1, 1],
+};
+
+/**
+ * 向かい合うペアのインデックス（上限ルール用）
+ */
+const FACING_PAIRS: [number, number][] = [
+  [0, 8],
+  [1, 7],
+  [2, 6],
+  [3, 5],
+];
+
+export type UpperLimitResult = {
+  maxNumber: number;
+  notificationType: number; // 0: 上限ルール発動, -1: 通常
+};
+
+/**
+ * 上限ルールの計算
+ * @param cellData 13×13のボードデータ
+ * @param x クリックされたマスのX座標
+ * @param y クリックされたマスのY座標
+ */
+export function calcUpperLimit(
+  cellData: number[][],
+  x: number,
+  y: number,
+): UpperLimitResult {
+  // 8近傍の絶対値を取得
+  const neighborValues: { [key: number]: number } = {};
+  for (const [keyStr, [dx, dy]] of Object.entries(DIRECTIONS)) {
+    const key = Number(keyStr);
+    const nx = (x + dx + 13) % 13;
+    const ny = (y + dy + 13) % 13;
+    neighborValues[key] = Math.abs(cellData[nx]?.[ny] ?? 0);
+  }
+
+  // 隣接最大値 + 1 を初期値とする
+  let maxNumber = Math.max(0, ...Object.values(neighborValues)) + 1;
+
+  // 向かい合うペアが同じ値なら上限ルール発動
+  let minFacingPair = 1000;
+  for (const [j, k] of FACING_PAIRS) {
+    const jVal = neighborValues[j] ?? 0;
+    const kVal = neighborValues[k] ?? 0;
+    if (jVal === kVal && jVal !== 0 && jVal < minFacingPair) {
+      minFacingPair = jVal;
+    }
+  }
+
+  let notificationType = -1;
+  if (minFacingPair !== 1000) {
+    maxNumber = minFacingPair;
+    notificationType = 0;
+  }
+
+  return { maxNumber, notificationType };
+}
+
+export type Coordinate = { x: number; y: number };
+
+/**
+ * 取り壊しルールの計算
+ * @param cellData 13×13のボードデータ
+ * @returns 取り壊し対象のマス座標リスト
+ */
+export function calcDemolition(cellData: number[][]): Coordinate[] {
+  const removedList: Coordinate[] = [];
+
+  for (let x = 0; x < 13; x++) {
+    for (let y = 0; y < 13; y++) {
+      const n = Math.abs(cellData[x]?.[y] ?? 0);
+
+      if (n <= 1) continue;
+
+      for (const [dx, dy] of Object.values(DIRECTIONS)) {
+        const currentChain: Coordinate[] = [];
+        let step = 1;
+
+        while (true) {
+          const nx = (x + dx * step + 13) % 13;
+          const ny = (y + dy * step + 13) % 13;
+
+          // 起点に戻ってきた場合
+          if (nx === x && ny === y) {
+            if (currentChain.length > 0) {
+              removedList.push(...currentChain);
+            }
+            break;
+          }
+
+          const currentValue = Math.abs(cellData[nx]?.[ny] ?? 0);
+
+          if (step === 1) {
+            if (currentValue !== n - 1) break;
+            currentChain.push({ x: nx, y: ny });
+          } else if (currentValue === n - 1) {
+            currentChain.push({ x: nx, y: ny });
+          } else if (currentValue === n) {
+            if (currentChain.length > 0) {
+              removedList.push(...currentChain);
+            }
+            break;
+          } else {
+            break;
+          }
+          step++;
+        }
+      }
+    }
+  }
+
+  return removedList;
+}

--- a/src/stores/game.ts
+++ b/src/stores/game.ts
@@ -1,4 +1,5 @@
 import { calcUpperLimit, calcDemolition } from "~/composables/useGameLogic";
+import { useNotificationStore } from "~/stores/notification";
 
 export const useGameStore = defineStore("game", () => {
   // ────────────── State ──────────────
@@ -29,6 +30,11 @@ export const useGameStore = defineStore("game", () => {
    * 取り壊し処理中フラグ（true中はタイル操作不可）
    */
   const isBeingRemoved = ref<boolean>(false);
+
+  /**
+   * 取り壊しタイマーのID（resetGame時にクリアするために保持）
+   */
+  let demolitionTimeoutId: ReturnType<typeof setTimeout> | undefined;
 
   // ────────────── Getters ──────────────
 
@@ -79,6 +85,8 @@ export const useGameStore = defineStore("game", () => {
    * 手番交代・取り壊しルールの計算・実行を行う
    */
   function submitMove(value: number): void {
+    if (!isEditable.value) return;
+
     const [x, y] = selectedCell.value;
     const row = cellData.value[x];
     if (row) row[y] = value * side.value;
@@ -87,11 +95,12 @@ export const useGameStore = defineStore("game", () => {
     selectedCell.value = [-1, -1];
     isBeingRemoved.value = true;
 
+    clearTimeout(demolitionTimeoutId);
     const removedList = calcDemolition(cellData.value);
 
     if (removedList.length > 0) {
       useNotificationStore().show(1);
-      setTimeout(() => {
+      demolitionTimeoutId = setTimeout(() => {
         for (const coord of removedList) {
           const r = cellData.value[coord.x];
           if (r) r[coord.y] = 0;
@@ -107,6 +116,7 @@ export const useGameStore = defineStore("game", () => {
    * ゲームをリセットする
    */
   function resetGame(): void {
+    clearTimeout(demolitionTimeoutId);
     cellData.value = [...Array(13)].map(() => Array(13).fill(0));
     side.value = 1;
     selectedCell.value = [-1, -1];

--- a/src/stores/game.ts
+++ b/src/stores/game.ts
@@ -1,0 +1,132 @@
+import { calcUpperLimit, calcDemolition } from "~/composables/useGameLogic";
+
+export const useGameStore = defineStore("game", () => {
+  // ────────────── State ──────────────
+
+  /**
+   * 13×13のマス目データ（青=正数, 赤=負数, 空=0）
+   */
+  const cellData = ref<number[][]>(
+    [...Array(13)].map(() => Array(13).fill(0)),
+  );
+
+  /**
+   * 手番（1=青, -1=赤）
+   */
+  const side = ref<number>(1);
+
+  /**
+   * 選択中のマスの座標（[-1, -1]=未選択）
+   */
+  const selectedCell = ref<[number, number]>([-1, -1]);
+
+  /**
+   * 選択中のマスへの入力上限値
+   */
+  const maxCellNumber = ref<number>(10);
+
+  /**
+   * 取り壊し処理中フラグ（true中はタイル操作不可）
+   */
+  const isBeingRemoved = ref<boolean>(false);
+
+  // ────────────── Getters ──────────────
+
+  /**
+   * 選択中のマスの現在値（未選択時は1000）
+   */
+  const selectedCellNumber = computed<number>(() => {
+    if (selectedCell.value[0] < 0) return 1000;
+    return cellData.value[selectedCell.value[0]]?.[selectedCell.value[1]] ?? 1000;
+  });
+
+  /**
+   * 数値入力が可能かどうか
+   */
+  const isEditable = computed<boolean>(
+    () =>
+      selectedCell.value[0] !== -1 &&
+      selectedCell.value[1] !== -1 &&
+      selectedCellNumber.value === 0,
+  );
+
+  // ────────────── Actions ──────────────
+
+  /**
+   * タイル選択・解除
+   * 上限ルールの計算も行い、maxCellNumber を更新する
+   */
+  function selectCell(x: number, y: number): void {
+    if (isBeingRemoved.value) return;
+
+    // 同じマスを再クリック → 選択解除
+    if (selectedCell.value[0] === x && selectedCell.value[1] === y) {
+      selectedCell.value = [-1, -1];
+      return;
+    }
+
+    const { maxNumber, notificationType } = calcUpperLimit(cellData.value, x, y);
+    maxCellNumber.value = maxNumber;
+    selectedCell.value = [x, y];
+
+    if (notificationType === 0) {
+      useNotificationStore().show(0);
+    }
+  }
+
+  /**
+   * 数値を確定する
+   * 手番交代・取り壊しルールの計算・実行を行う
+   */
+  function submitMove(value: number): void {
+    const [x, y] = selectedCell.value;
+    const row = cellData.value[x];
+    if (row) row[y] = value * side.value;
+
+    side.value *= -1;
+    selectedCell.value = [-1, -1];
+    isBeingRemoved.value = true;
+
+    const removedList = calcDemolition(cellData.value);
+
+    if (removedList.length > 0) {
+      useNotificationStore().show(1);
+      setTimeout(() => {
+        for (const coord of removedList) {
+          const r = cellData.value[coord.x];
+          if (r) r[coord.y] = 0;
+        }
+        isBeingRemoved.value = false;
+      }, 2000);
+    } else {
+      isBeingRemoved.value = false;
+    }
+  }
+
+  /**
+   * ゲームをリセットする
+   */
+  function resetGame(): void {
+    cellData.value = [...Array(13)].map(() => Array(13).fill(0));
+    side.value = 1;
+    selectedCell.value = [-1, -1];
+    maxCellNumber.value = 10;
+    isBeingRemoved.value = false;
+  }
+
+  return {
+    // State
+    cellData,
+    side,
+    selectedCell,
+    maxCellNumber,
+    isBeingRemoved,
+    // Getters
+    selectedCellNumber,
+    isEditable,
+    // Actions
+    selectCell,
+    submitMove,
+    resetGame,
+  };
+});

--- a/src/stores/notification.ts
+++ b/src/stores/notification.ts
@@ -1,0 +1,46 @@
+export const useNotificationStore = defineStore("notification", () => {
+  const notificationData: [string, string][] = [
+    [
+      "ルール：上限",
+      "同じ道路番号 n に挟まれている場合，新たに設置する道路番号は n 以下である必要があります",
+    ],
+    [
+      "ルール：取り壊し",
+      "道路番号ｎ-1のマスを、道路番号 n の道で挟んだとき，挟まれたマスの道は取り壊されます。",
+    ],
+  ];
+
+  const text = ref<[string, string]>(["", ""]);
+  const isVisible = ref(false);
+  const key = ref(0);
+
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+  function show(id: number): void {
+    const entry = notificationData[id];
+    if (entry === undefined) return;
+    text.value = entry;
+
+    if (isVisible.value) {
+      isVisible.value = false;
+      clearTimeout(timeoutId);
+      setTimeout(() => {
+        key.value++;
+        isVisible.value = true;
+        scheduleHide();
+      }, 100);
+    } else {
+      isVisible.value = true;
+      scheduleHide();
+    }
+  }
+
+  function scheduleHide(): void {
+    clearTimeout(timeoutId);
+    timeoutId = setTimeout(() => {
+      isVisible.value = false;
+    }, 5000);
+  }
+
+  return { text, isVisible, key, show };
+});

--- a/src/stores/notification.ts
+++ b/src/stores/notification.ts
@@ -15,6 +15,7 @@ export const useNotificationStore = defineStore("notification", () => {
   const key = ref(0);
 
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  let reshowTimeoutId: ReturnType<typeof setTimeout> | undefined;
 
   function show(id: number): void {
     const entry = notificationData[id];
@@ -24,12 +25,14 @@ export const useNotificationStore = defineStore("notification", () => {
     if (isVisible.value) {
       isVisible.value = false;
       clearTimeout(timeoutId);
-      setTimeout(() => {
+      clearTimeout(reshowTimeoutId);
+      reshowTimeoutId = setTimeout(() => {
         key.value++;
         isVisible.value = true;
         scheduleHide();
       }, 100);
     } else {
+      clearTimeout(reshowTimeoutId);
       isVisible.value = true;
       scheduleHide();
     }


### PR DESCRIPTION
## Summary

- `pinia` / `@pinia/nuxt` をインストールし、Nuxt モジュールに追加
- `composables/useCellCoords.ts`: タイル番号↔セル座標の変換を純粋関数として切り出し
- `composables/useGameLogic.ts`: 上限ルール・取り壊しルールのロジックをテスト可能な純粋関数として切り出し
- `stores/game.ts`: ゲーム状態（cellData, side, selectedCell など）とアクションを集約
- `stores/notification.ts`: 通知 UI 状態を分離
- `boardTile.vue`: Props を `number` のみに削減、ストアを直接参照
- `boardMenu.vue`: Props/Emits を全削除、ストアを直接参照
- `boardMain.vue`: ロジックをストアに委譲し script を大幅に軽量化

## Test plan

- [ ] ボードのタイルをクリックして数値を入力できる
- [ ] 手番が青→赤→青と切り替わる
- [ ] 上限ルールの通知が表示される
- [ ] 取り壊しルールが正しく動作する
- [ ] 道（パス）が正しく描画される

🤖 Generated with [Claude Code](https://claude.com/claude-code)